### PR TITLE
feat: add persistent app state

### DIFF
--- a/src/tilemap-editor.js
+++ b/src/tilemap-editor.js
@@ -1420,6 +1420,16 @@
             appState
         }
     ) => {
+        let savedState;
+        try {
+            savedState = localStorage.getItem('tilemapEditorState');
+            if (savedState) {
+                appState = JSON.parse(savedState);
+            }
+        } catch (e) {
+            console.warn('Failed to load saved state', e);
+        }
+
         // Attach
         const attachTo = document.getElementById(attachToId);
         if(attachTo === null) return;
@@ -1461,7 +1471,11 @@
             },
             acceptFile: "application/JSON"
         }
-        apiOnUpdateCallback = onUpdate;
+        apiOnUpdateCallback = (...args) => {
+            onUpdate(...args);
+            saveStateToLocalStorage();
+        };
+        exports.onUpdate = apiOnUpdateCallback;
 
         if(onMouseUp){
             apiOnMouseUp = onMouseUp;
@@ -1927,6 +1941,13 @@
             fileMenuDropDown.appendChild(menuItem);
             return menuItem;
         }
+        makeMenuItem('Clear saved state', 'clearSavedState', 'Remove saved editor state').onclick = () => {
+            try {
+                localStorage.removeItem('tilemapEditorState');
+            } catch (e) {
+                console.warn('Failed to clear saved state', e);
+            }
+        };
         Object.entries(tileMapExporters).forEach(([key, exporter])=>{
             makeMenuItem(exporter.name, key,exporter.description).onclick = () => {
                 exporter.transformer(getExportData());
@@ -2006,6 +2027,13 @@
     exports.getState = () => {
         return getAppState();
     }
+    const saveStateToLocalStorage = () => {
+        try {
+            localStorage.setItem('tilemapEditorState', JSON.stringify(getAppState()));
+        } catch (e) {
+            console.warn('Failed to save state', e);
+        }
+    };
 
     exports.onUpdate = apiOnUpdateCallback;
     exports.onMouseUp = apiOnMouseUp;


### PR DESCRIPTION
## Summary
- persist app state to localStorage and restore on startup
- save state whenever map updates occur
- add File menu action to clear stored editor state

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ae9e738c83268e7fb10236fcad31