### PR TITLE
Add draggable layer reordering

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -299,6 +299,7 @@ cursor: pointer;
   align-items: center;
   padding: 0 3px;
   border-bottom: 1px solid #80808045;
+  cursor: move;
 }
 .tileset_info{
   margin-left: 3px;
@@ -322,6 +323,10 @@ cursor: pointer;
 }
 .layer:hover{
   background-color: rgba(255, 255, 0, 0.05);
+}
+
+.layer.drop-target {
+  background-color: rgba(0, 255, 255, 0.2);
 }
 .add_layer {
   display: flex;

--- a/src/tilemap-editor.js
+++ b/src/tilemap-editor.js
@@ -210,7 +210,7 @@
     const updateLayers = () => {
         layersElement.innerHTML = maps[ACTIVE_MAP].layers.map((layer, index)=>{
             return `
-              <div class="layer">
+              <div class="layer" draggable="true" data-layer-index="${index}">
                 <div id="selectLayerBtn-${index}" class="layer select_layer" tile-layer="${index}" title="${layer.name}">${layer.name} ${layer.opacity < 1 ? ` (${layer.opacity})` : ""}</div>
                 <span id="setLayerVisBtn-${index}" vis-layer="${index}"></span>
                 <div id="trashLayerBtn-${index}" trash-layer="${index}" ${maps[ACTIVE_MAP].layers.length > 1 ? "":`disabled="true"`}>🗑️</div>
@@ -219,6 +219,35 @@
         }).reverse().join("\n")
 
         maps[ACTIVE_MAP].layers.forEach((_,index)=>{
+            const layerEl = document.querySelector(`.layer[data-layer-index="${index}"]`);
+            layerEl.addEventListener("dragstart", e => {
+                e.dataTransfer.setData("text/plain", String(index));
+            });
+            layerEl.addEventListener("dragover", e => {
+                e.preventDefault();
+                layerEl.classList.add("drop-target");
+            });
+            layerEl.addEventListener("dragleave", () => {
+                layerEl.classList.remove("drop-target");
+            });
+            layerEl.addEventListener("drop", e => {
+                e.preventDefault();
+                layerEl.classList.remove("drop-target");
+                const fromIndex = Number(e.dataTransfer.getData("text/plain"));
+                const toIndex = index;
+                if(fromIndex !== toIndex){
+                    const layers = maps[ACTIVE_MAP].layers;
+                    [layers[fromIndex], layers[toIndex]] = [layers[toIndex], layers[fromIndex]];
+                    if(currentLayer === fromIndex){
+                        currentLayer = toIndex;
+                    } else if(currentLayer === toIndex){
+                        currentLayer = fromIndex;
+                    }
+                    updateLayers();
+                    addToUndoStack();
+                }
+            });
+
             document.getElementById(`selectLayerBtn-${index}`).addEventListener("click",e=>{
                 setLayer(e.target.getAttribute("tile-layer"));
                 addToUndoStack();


### PR DESCRIPTION
## Summary
- allow layers to be dragged and dropped to reorder
- highlight layers when dragged over and show move cursor

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0b28249448326bf18e272f76f4628