### PR TITLE
feat: allow renaming layers

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -300,6 +300,10 @@ cursor: pointer;
   padding: 0 3px;
   border-bottom: 1px solid #80808045;
 }
+.rename_layer {
+  cursor: pointer;
+  padding: 0 3px;
+}
 .tileset_info{
   margin-left: 3px;
   color: #ececcd;

--- a/src/tilemap-editor.js
+++ b/src/tilemap-editor.js
@@ -199,6 +199,16 @@
         draw();
     }
 
+    const renameLayer = (index) => {
+        const layerNumber = Number(index);
+        const newName = prompt("Enter layer name", maps[ACTIVE_MAP].layers[layerNumber].name);
+        if(newName !== null){
+            maps[ACTIVE_MAP].layers[layerNumber].name = newName;
+            updateLayers();
+            addToUndoStack();
+        }
+    }
+
     const addLayer = () => {
         const newLayerName = prompt("Enter layer name", `Layer${maps[ACTIVE_MAP].layers.length + 1}`);
         if(newLayerName !== null) {
@@ -213,6 +223,7 @@
               <div class="layer">
                 <div id="selectLayerBtn-${index}" class="layer select_layer" tile-layer="${index}" title="${layer.name}">${layer.name} ${layer.opacity < 1 ? ` (${layer.opacity})` : ""}</div>
                 <span id="setLayerVisBtn-${index}" vis-layer="${index}"></span>
+                <div id="renameLayerBtn-${index}" rename-layer="${index}" class="rename_layer">✏️</div>
                 <div id="trashLayerBtn-${index}" trash-layer="${index}" ${maps[ACTIVE_MAP].layers.length > 1 ? "":`disabled="true"`}>🗑️</div>
               </div>
             `
@@ -226,6 +237,9 @@
             document.getElementById(`setLayerVisBtn-${index}`).addEventListener("click",e=>{
                 setLayerIsVisible(e.target.getAttribute("vis-layer"))
                 addToUndoStack();
+            })
+            document.getElementById(`renameLayerBtn-${index}`).addEventListener("click",e=>{
+                renameLayer(e.target.getAttribute("rename-layer"))
             })
             document.getElementById(`trashLayerBtn-${index}`).addEventListener("click",e=>{
                 trashLayer(e.target.getAttribute("trash-layer"))


### PR DESCRIPTION
## Summary
- add renameLayer handler and button to layer list
- style rename control

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b0b288a0c88326892ba6b5734ba9f7