### PR TITLE
Add layer locking to tilemap editor

### DIFF
--- a/src/tilemap-editor.js
+++ b/src/tilemap-editor.js
@@ -79,7 +79,7 @@
             .replace(/{{height}}/g, height)
             .replace(/{{mapTileWidth}}/g, mapTileWidth);
     }
-    const getEmptyLayer = (name="layer")=> ({tiles:{}, visible: true, name, animatedTiles: {}, opacity: 1});
+    const getEmptyLayer = (name="layer")=> ({tiles:{}, visible: true, name, animatedTiles: {}, opacity: 1, locked: false});
     let tilesetImage, canvas, tilesetContainer, tilesetSelection, cropSize,
         confirmBtn, tilesetGridContainer,
         layersElement, resizingCanvas, mapTileHeight, mapTileWidth, tileDataSel,tileFrameSel,tileAnimSel,
@@ -191,6 +191,14 @@
         draw();
     }
 
+    const setLayerIsLocked = (layer, override = null) => {
+        const layerNumber = Number(layer);
+        maps[ACTIVE_MAP].layers[layerNumber].locked = override ?? !maps[ACTIVE_MAP].layers[layerNumber].locked;
+        document
+            .getElementById(`lockLayerBtn-${layer}`)
+            .innerHTML = maps[ACTIVE_MAP].layers[layerNumber].locked ? "🔒" : "🔓";
+    }
+
     const trashLayer = (layer) => {
         const layerNumber = Number(layer);
         maps[ACTIVE_MAP].layers.splice(layerNumber, 1);
@@ -223,6 +231,7 @@
               <div class="layer" draggable="true" data-layer-index="${index}">
                 <div id="selectLayerBtn-${index}" class="layer select_layer" tile-layer="${index}" title="${layer.name}">${layer.name} ${layer.opacity < 1 ? ` (${layer.opacity})` : ""}</div>
                 <span id="setLayerVisBtn-${index}" vis-layer="${index}"></span>
+                <span id="lockLayerBtn-${index}" lock-layer="${index}"></span>
                 <div id="renameLayerBtn-${index}" rename-layer="${index}" class="rename_layer">✏️</div>
                 <div id="trashLayerBtn-${index}" trash-layer="${index}" ${maps[ACTIVE_MAP].layers.length > 1 ? "":`disabled="true"`}>🗑️</div>
               </div>
@@ -267,6 +276,10 @@
                 setLayerIsVisible(e.target.getAttribute("vis-layer"))
                 addToUndoStack();
             })
+            document.getElementById(`lockLayerBtn-${index}`).addEventListener("click",e=>{
+                setLayerIsLocked(e.target.getAttribute("lock-layer"))
+                addToUndoStack();
+            })
             document.getElementById(`renameLayerBtn-${index}`).addEventListener("click",e=>{
                 renameLayer(e.target.getAttribute("rename-layer"))
             })
@@ -275,6 +288,7 @@
                 addToUndoStack();
             })
             setLayerIsVisible(index, true);
+            setLayerIsLocked(index, maps[ACTIVE_MAP].layers[index].locked);
         })
         setLayer(currentLayer);
     }
@@ -568,12 +582,14 @@
     }
 
     const removeTile=(key) =>{
+        if (maps[ACTIVE_MAP].layers[currentLayer].locked) return;
         delete maps[ACTIVE_MAP].layers[currentLayer].tiles[key];
         if (key in (maps[ACTIVE_MAP].layers[currentLayer].animatedTiles || {})) delete maps[ACTIVE_MAP].layers[currentLayer].animatedTiles[key];
     }
 
     const isFlippedOnX = () => document.getElementById("toggleFlipX").checked;
     const addSelectedTiles = (key, tiles) => {
+        if (maps[ACTIVE_MAP].layers[currentLayer].locked) return;
         const [x, y] = key.split("-");
         const tilesPatch = tiles || selection; // tiles is opt override for selection for fancy things like random patch of tiles
         const {x: startX, y: startY} = tilesPatch[0];// add selection override
@@ -597,6 +613,7 @@
     const getSelectedFrameCount = () => getCurrentFrames()?.frameCount || 1;
     const shouldNotAddAnimatedTile = () => (tileDataSel.value !== "frames" && getSelectedFrameCount() !== 1) || Object.keys(tileSets[tilesetDataSel.value]?.frames).length === 0;
     const addTile = (key) => {
+        if (maps[ACTIVE_MAP].layers[currentLayer].locked) return;
         if (shouldNotAddAnimatedTile()) {
             addSelectedTiles(key);
         } else {
@@ -613,6 +630,7 @@
     }
 
     const addRandomTile = (key) =>{
+        if (maps[ACTIVE_MAP].layers[currentLayer].locked) return;
         // TODO add probability for empty
         if (shouldNotAddAnimatedTile()) {
             maps[ACTIVE_MAP].layers[currentLayer].tiles[key] = selection[Math.floor(Math.random()*selection.length)];
@@ -628,6 +646,7 @@
     }
 
     const fillEmptyOrSameTiles = (key) => {
+        if (maps[ACTIVE_MAP].layers[currentLayer].locked) return;
         const pickedTile = maps[ACTIVE_MAP].layers[currentLayer].tiles[key];
         Array.from({length: mapTileWidth * mapTileHeight}, (x, i) => i).map(tile=>{
             const x = tile % mapTileWidth;
@@ -697,7 +716,7 @@
     }
 
     const toggleTile=(event)=> {
-        if(ACTIVE_TOOL === TOOLS.PAN || !maps[ACTIVE_MAP].layers[currentLayer].visible) return;
+        if(ACTIVE_TOOL === TOOLS.PAN || !maps[ACTIVE_MAP].layers[currentLayer].visible || maps[ACTIVE_MAP].layers[currentLayer].locked) return;
 
         const {x,y} = getSelectedTile(event)[0];
         const key = `${x}-${y}`;


### PR DESCRIPTION
## Summary
- add `locked` flag to map layers
- provide lock/unlock button for each layer
- skip drawing and erasing on locked layers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0b74115f083269060f780a25d25bb