### PR TITLE
Integrate GoldenLayout structure for editor layout

### DIFF
--- a/src/tilemap-editor.js
+++ b/src/tilemap-editor.js
@@ -1327,8 +1327,33 @@
 
         if (SIZE_OF_CROP < 12) ZOOM = 2;// Automatically start with zoom 2 when the tilesize is tiny
         // Attach elements
-        attachTo.innerHTML = await getHtml(canvasWidth, canvasHeight);
+        attachTo.innerHTML = '<div id="layoutRoot"></div>';
         attachTo.className = "tilemap_editor_root";
+
+        const config = {
+            root: {
+                type: 'row',
+                content: [
+                    { type: 'component', componentName: 'Tileset', title: 'Tileset' },
+                    { type: 'component', componentName: 'Map', title: 'Map' },
+                    { type: 'component', componentName: 'Layers', title: 'Layers' }
+                ]
+            }
+        };
+
+        const layout = new GoldenLayout(config, document.getElementById('layoutRoot'));
+
+        layout.registerComponent('Tileset', container => {
+            container.getElement().html('<div class="tileset-container"><div class="tileset-container-selection"></div><div id="tilesetGridContainer"></div><input id="cropSize" type="hidden" /><button id="confirmBtn"></button></div>');
+        });
+        layout.registerComponent('Map', container => {
+            container.getElement().html(`<canvas id="mapCanvas" width="${canvasWidth}" height="${canvasHeight}"></canvas>`);
+        });
+        layout.registerComponent('Layers', container => {
+            container.getElement().html('<div id="layers"></div>');
+        });
+        layout.init();
+
         tilesetImage = document.createElement('img');
         cropSize = document.getElementById('cropSize');
 


### PR DESCRIPTION
## Summary
- Replace template HTML injection with a layoutRoot placeholder.
- Create GoldenLayout config with Tileset, Map, and Layers components.
- Register components and initialize GoldenLayout.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0bb4c280c8326adda4e44acf21a20