### PR TITLE
feat: enable Golden Layout dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Create your tile map with this online Tile Map Editor" />
     <link rel="stylesheet" href="src/styles.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/golden-layout@2.6.0/dist/css/goldenlayout-base.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/golden-layout@2.6.0/dist/css/themes/goldenlayout-light-theme.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/golden-layout@2.6.0/dist/css/themes/goldenlayout-dark-theme.css">
 
     <script type="module" src="https://cdn.jsdelivr.net/npm/@antosubash/golden-layout@2.6.0/dist/bundle/esm/golden-layout.js"></script>
 


### PR DESCRIPTION
## Summary
- switch Golden Layout CSS to dark theme to enable dark mode

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b149260de88326a18c74fd6135ab42