### PR TITLE
Remove Golden Layout script tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/golden-layout@2.6.0/dist/css/goldenlayout-base.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/golden-layout@2.6.0/dist/css/themes/goldenlayout-light-theme.css">
 
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@antosubash/golden-layout@2.6.0/dist/bundle/esm/golden-layout.js"></script>
 
     <link rel="manifest" href="manifest.webmanifest">
     <meta name="theme-color" content="#317EFB">


### PR DESCRIPTION
## Summary
- remove Golden Layout script tag from index.html
- restore tilemap-editor.js to original static import

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b14978fe6c83269b970107b0cd1fd5