### PR TITLE
Handle layout resizing on window resize

### DIFF
--- a/src/tilemap-editor.js
+++ b/src/tilemap-editor.js
@@ -1368,6 +1368,7 @@ const TilemapEditor = {};
                 ]
             }
         }, layoutContainer);
+        window.addEventListener('resize', () => layout.updateSize());
         layout.registerComponent('Tileset', container => {
             container.element.innerHTML = tilesetTemplate;
             const compEl = container.getElement();


### PR DESCRIPTION
## Summary
- call `layout.updateSize()` whenever the window resizes so panels remain sized correctly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b164e52a2883268307f762a5edcfbd