### PR TITLE
Remove obsolete TODO about empty tile probability

### DIFF
--- a/src/tilemap-editor.js
+++ b/src/tilemap-editor.js
@@ -627,7 +627,6 @@ const TilemapEditor = {};
 
     const addRandomTile = (key) =>{
         if (maps[ACTIVE_MAP].layers[currentLayer].locked) return;
-        // TODO add probability for empty
         if (shouldNotAddAnimatedTile()) {
             maps[ACTIVE_MAP].layers[currentLayer].tiles[key] = selection[Math.floor(Math.random()*selection.length)];
         }else {


### PR DESCRIPTION
## Summary
- remove outdated TODO comment about empty tile probability in random tile placement

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b18c7ab0a88326b9054a55867098a1