### PR TITLE
Fix draggable element check in onMouseUp handler

### DIFF
--- a/src/tilemap-editor.js
+++ b/src/tilemap-editor.js
@@ -29,7 +29,7 @@ const TilemapEditor = {};
             isMouseDown = true;
         }
         const onMouseUp = () => {
-            if(!element.getAttribute("isDraggable") === "false") return;
+            if (element.getAttribute("isDraggable") === "false") return;
             isMouseDown = false;
             elementX = parseInt(element.style.left) || 0;
             elementY = parseInt(element.style.top) || 0;


### PR DESCRIPTION
## Summary
- Ensure onMouseUp skips when `isDraggable` attribute is false

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b18cbea82c83268690357bfe419a27