### PR TITLE
fix: prevent layer drag from intercepting button taps

### DIFF
--- a/src/tilemap-editor.js
+++ b/src/tilemap-editor.js
@@ -236,6 +236,10 @@ const TilemapEditor = {};
         maps[ACTIVE_MAP].layers.forEach((_,index)=>{
             const layerEl = document.querySelector(`.layer[data-layer-index="${index}"]`);
             const onPointerDown = (e) => {
+                if (e.target.closest('[tile-layer],[vis-layer],[lock-layer],[rename-layer],[trash-layer]')) {
+                    return;
+                }
+
                 const draggedItem = e.currentTarget;
                 draggedItem.classList.add('dragging');
 


### PR DESCRIPTION
## Summary
- ignore pointerdown events from layer control buttons when handling layer drag

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1972bb28483269815262908681eed