### PR TITLE
Use network-first strategy in service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,7 +364,7 @@
     });
 
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js').then(reg => {
+      navigator.serviceWorker.register('/sw.js', { updateViaCache: 'none' }).then(reg => {
         console.log('Service Worker Registered');
         reg.addEventListener('updatefound', () => {
           // A wild service worker has appeared in reg.installing!


### PR DESCRIPTION
## Summary
- Ensure service worker fetches from network first and falls back to cache
- Register service worker with `updateViaCache: 'none'` for uncached updates

## Testing
- `node --check sw.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1992a42f8832690d328c65dc47243