### PR TITLE
Add drag handle for layer reordering

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -284,7 +284,12 @@ cursor: pointer;
   align-items: center;
   padding: 0 3px;
   border-bottom: 1px solid #80808045;
-  cursor: move;
+}
+.layer-handle {
+  cursor: grab;
+}
+.layer-handle:active {
+  cursor: grabbing;
 }
 .rename_layer {
   cursor: pointer;

--- a/src/tilemap-editor.js
+++ b/src/tilemap-editor.js
@@ -223,24 +223,26 @@ const TilemapEditor = {};
     const updateLayers = () => {
         layersElement.innerHTML = maps[ACTIVE_MAP].layers.map((layer, index)=>{
             return `
-              <div class="layer" draggable="true" data-layer-index="${index}">
-                <div id="selectLayerBtn-${index}" class="layer select_layer" tile-layer="${index}" title="${layer.name}">${layer.name} ${layer.opacity < 1 ? ` (${layer.opacity})` : ""}</div>
-                <span id="setLayerVisBtn-${index}" vis-layer="${index}"></span>
-                <span id="lockLayerBtn-${index}" lock-layer="${index}"></span>
-                <div id="renameLayerBtn-${index}" rename-layer="${index}" class="rename_layer">✏️</div>
-                <div id="trashLayerBtn-${index}" trash-layer="${index}" ${maps[ACTIVE_MAP].layers.length > 1 ? "":`disabled="true"`}>🗑️</div>
+              <div class="layer" data-layer-index="${index}">
+                <div class="layer-handle" handle-layer="${index}" draggable="false">☰</div>
+                <div id="selectLayerBtn-${index}" class="layer select_layer" tile-layer="${index}" title="${layer.name}" draggable="false">${layer.name} ${layer.opacity < 1 ? ` (${layer.opacity})` : ""}</div>
+                <span id="setLayerVisBtn-${index}" vis-layer="${index}" draggable="false"></span>
+                <span id="lockLayerBtn-${index}" lock-layer="${index}" draggable="false"></span>
+                <div id="renameLayerBtn-${index}" rename-layer="${index}" class="rename_layer" draggable="false">✏️</div>
+                <div id="trashLayerBtn-${index}" trash-layer="${index}" ${maps[ACTIVE_MAP].layers.length > 1 ? "" : `disabled="true"`} draggable="false">🗑️</div>
               </div>
             `
         }).reverse().join("\n")
 
         maps[ACTIVE_MAP].layers.forEach((_,index)=>{
             const layerEl = document.querySelector(`.layer[data-layer-index="${index}"]`);
+            const handleEl = layerEl.querySelector('.layer-handle');
             const onPointerDown = (e) => {
                 if (e.target.closest('[tile-layer],[vis-layer],[lock-layer],[rename-layer],[trash-layer]')) {
                     return;
                 }
 
-                const draggedItem = e.currentTarget;
+                const draggedItem = layerEl;
                 draggedItem.classList.add('dragging');
 
                 const onPointerMove = (e) => {
@@ -289,7 +291,7 @@ const TilemapEditor = {};
                 document.addEventListener('pointerup', onPointerUp);
             };
 
-            layerEl.addEventListener('pointerdown', onPointerDown);
+            handleEl.addEventListener('pointerdown', onPointerDown);
 
             document.getElementById(`selectLayerBtn-${index}`).addEventListener("pointerup",e=>{
                 e.stopPropagation();


### PR DESCRIPTION
## Summary
- restrict layer dragging to a new handle element
- update drag logic to attach events to the handle
- adjust styling to show grab cursor and drop move cursor on handle

## Testing
- ⚠️ `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b19dc599788326a58e9f24e77b9175