### PR TITLE
feat: add editor context and reducer

### DIFF
--- a/src/context/EditorContext.jsx
+++ b/src/context/EditorContext.jsx
@@ -1,0 +1,73 @@
+import React, { createContext, useReducer, useContext } from 'react';
+
+export const TOOLS = {
+  BRUSH: 0,
+  ERASE: 1,
+  PAN: 2,
+  PICK: 3,
+  RAND: 4,
+  FILL: 5,
+};
+
+export const initialState = {
+  prevActiveTool: TOOLS.BRUSH,
+  activeTool: TOOLS.BRUSH,
+  activeMap: '',
+  displaySymbols: false,
+  showGrid: false,
+  selection: [],
+  currentLayer: 0,
+  isMouseDown: false,
+  maps: {},
+  tileSets: {},
+};
+
+export const editorReducer = (state, action) => {
+  switch (action.type) {
+    case 'SET_TOOL':
+      return {
+        ...state,
+        prevActiveTool: state.activeTool,
+        activeTool: action.tool,
+      };
+    case 'ADD_MAP':
+      return {
+        ...state,
+        maps: { ...state.maps, [action.map.name]: action.map },
+        activeMap: action.map.name,
+      };
+    case 'UPDATE_LAYER': {
+      const { mapName, layerIndex, layerData } = action;
+      const map = state.maps[mapName];
+      if (!map) return state;
+      const layers = map.layers.map((l, i) =>
+        i === layerIndex ? { ...l, ...layerData } : l
+      );
+      return {
+        ...state,
+        maps: { ...state.maps, [mapName]: { ...map, layers } },
+      };
+    }
+    case 'SET_ACTIVE_MAP':
+      return { ...state, activeMap: action.name };
+    case 'TOGGLE_GRID':
+      return { ...state, showGrid: !state.showGrid };
+    default:
+      return state;
+  }
+};
+
+const EditorContext = createContext();
+
+export const EditorProvider = ({ children }) => {
+  const [state, dispatch] = useReducer(editorReducer, initialState);
+  return (
+    <EditorContext.Provider value={{ state, dispatch, TOOLS }}>
+      {children}
+    </EditorContext.Provider>
+  );
+};
+
+export const useEditor = () => useContext(EditorContext);
+
+export default EditorContext;

--- a/src/context/EditorContext.test.js
+++ b/src/context/EditorContext.test.js
@@ -1,0 +1,32 @@
+import { editorReducer, initialState, TOOLS } from './EditorContext';
+
+describe('editorReducer', () => {
+  it('sets the active tool and preserves previous tool', () => {
+    const state = { ...initialState, activeTool: TOOLS.BRUSH };
+    const result = editorReducer(state, { type: 'SET_TOOL', tool: TOOLS.ERASE });
+    expect(result.activeTool).toBe(TOOLS.ERASE);
+    expect(result.prevActiveTool).toBe(TOOLS.BRUSH);
+  });
+
+  it('adds a new map and sets it active', () => {
+    const map = { name: 'map1', layers: [] };
+    const result = editorReducer(initialState, { type: 'ADD_MAP', map });
+    expect(result.maps.map1).toEqual(map);
+    expect(result.activeMap).toBe('map1');
+  });
+
+  it('updates an existing layer in a map', () => {
+    const baseState = {
+      ...initialState,
+      maps: { map1: { name: 'map1', layers: [{ name: 'layer1', visible: true }] } },
+      activeMap: 'map1',
+    };
+    const result = editorReducer(baseState, {
+      type: 'UPDATE_LAYER',
+      mapName: 'map1',
+      layerIndex: 0,
+      layerData: { visible: false },
+    });
+    expect(result.maps.map1.layers[0].visible).toBe(false);
+  });
+});

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { EditorProvider } from './context/EditorContext';
 
 ReactDOM.createRoot(document.getElementById('tilemapjs_root')).render(
   <React.StrictMode>
-    <App />
+    <EditorProvider>
+      <App />
+    </EditorProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add EditorContext with reducer actions for tools, maps, and layers
- wrap app with EditorProvider to share state
- test reducer actions for predictable state updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2d64f73608326807278165284b630