### PR TITLE
Add layer deletion button and tests

### DIFF
--- a/src/components/LayersPanel.jsx
+++ b/src/components/LayersPanel.jsx
@@ -69,6 +69,29 @@ export default function LayersPanel() {
     setEditorState({ ...editorState, activeLayer: layerIndex });
   };
 
+  const deleteLayer = (layerIndex) => {
+    if (confirm('Are you sure you want to delete this layer?')) {
+      const newLayers = layers.filter((_, i) => i !== layerIndex);
+      let newActiveLayer = editorState.activeLayer;
+      if (newActiveLayer === layerIndex) {
+        newActiveLayer = Math.max(0, newActiveLayer - 1);
+      } else if (newActiveLayer > layerIndex) {
+        newActiveLayer -= 1;
+      }
+      setEditorState({
+        ...editorState,
+        maps: {
+          ...maps,
+          [activeMap]: {
+            ...activeMapData,
+            layers: newLayers,
+          },
+        },
+        activeLayer: newActiveLayer,
+      });
+    }
+  };
+
   return (
     <div className="card_right-column layers">
       <div id="mapSelectContainer" className="tilemaps_selector">
@@ -125,13 +148,20 @@ export default function LayersPanel() {
       </label>
       <div className="layers" id="layers">
         {layers.map((layer, index) => (
-          <div key={index} className={`layer ${editorState.activeLayer === index ? 'active' : ''}`} data-layer-index={index}>
+          <div
+            key={index}
+            className={`layer ${editorState.activeLayer === index ? 'active' : ''}`}
+            data-layer-index={index}
+          >
             <div className="layer-handle" ref={handleRef}>☰</div>
             <div className="layer select_layer" onClick={() => setLayer(index)} title={layer.name}>
               {layer.name} {layer.opacity < 1 ? ` (${layer.opacity})` : ''}
             </div>
             <span onClick={() => setLayerIsVisible(index)}>{layer.visible ? '👁️' : '👓'}</span>
             <span onClick={() => setLayerIsLocked(index)}>{layer.locked ? '🔒' : '🔓'}</span>
+            <button className="delete-layer" title="Delete layer" onClick={() => deleteLayer(index)}>
+              🗑️
+            </button>
           </div>
         ))}
       </div>

--- a/src/components/LayersPanel.test.jsx
+++ b/src/components/LayersPanel.test.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen, fireEvent } from '../utils/test-utils';
+import LayersPanel from './LayersPanel';
+import EditorContext from '../context/EditorContext';
+
+test('deleting a layer removes the correct layer', () => {
+  const mockEditorState = {
+    maps: {
+      Map_1: {
+        layers: [
+          { name: 'Layer 1', visible: true, locked: false, opacity: 1 },
+          { name: 'Layer 2', visible: true, locked: false, opacity: 1 },
+        ],
+      },
+    },
+    activeMap: 'Map_1',
+    activeLayer: 0,
+  };
+  const setEditorState = jest.fn();
+  global.confirm = jest.fn(() => true);
+
+  render(
+    <EditorContext.Provider value={{ editorState: mockEditorState, setEditorState }}>
+      <LayersPanel />
+    </EditorContext.Provider>
+  );
+
+  const deleteButtons = screen.getAllByTitle('Delete layer');
+  fireEvent.click(deleteButtons[1]);
+
+  expect(setEditorState).toHaveBeenCalledWith({
+    ...mockEditorState,
+    maps: {
+      Map_1: {
+        layers: [
+          { name: 'Layer 1', visible: true, locked: false, opacity: 1 },
+        ],
+      },
+    },
+    activeLayer: 0,
+  });
+});


### PR DESCRIPTION
## Summary
- Add delete button to each layer in LayersPanel and update state when removing
- Implement unit test to ensure deleting removes the correct layer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b33f4661108326a5ab0980ee6a32cf