### PR TITLE
feat: add layer creation button

### DIFF
--- a/src/components/LayersPanel.jsx
+++ b/src/components/LayersPanel.jsx
@@ -69,6 +69,35 @@ export default function LayersPanel() {
     setEditorState({ ...editorState, activeLayer: layerIndex });
   };
 
+  const addLayer = () => {
+    const newLayerName = prompt(
+      'Enter layer name',
+      `Layer${layers.length + 1}`
+    );
+    if (newLayerName !== null) {
+      const newLayers = [
+        ...layers,
+        {
+          tiles: {},
+          visible: true,
+          name: newLayerName,
+          opacity: 1,
+          locked: false,
+        },
+      ];
+      setEditorState({
+        ...editorState,
+        maps: {
+          ...maps,
+          [activeMap]: {
+            ...activeMapData,
+            layers: newLayers,
+          },
+        },
+      });
+    }
+  };
+
   return (
     <div className="card_right-column layers">
       <div id="mapSelectContainer" className="tilemaps_selector">
@@ -121,7 +150,7 @@ export default function LayersPanel() {
         <label id="activeLayerLabel" className="menu">
           Editing Layer
         </label>
-        <button id="addLayerBtn" title="Add layer">+</button>
+        <button id="addLayerBtn" title="Add layer" onClick={addLayer}>+</button>
       </label>
       <div className="layers" id="layers">
         {layers.map((layer, index) => (

--- a/src/components/LayersPanel.test.jsx
+++ b/src/components/LayersPanel.test.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen, fireEvent } from '../utils/test-utils';
+import LayersPanel from './LayersPanel';
+import EditorContext from '../context/EditorContext';
+
+const mockEditorState = {
+  maps: {
+    testMap: {
+      name: 'Test Map',
+      layers: [
+        { tiles: {}, visible: true, name: 'Layer1', opacity: 1, locked: false },
+      ],
+    },
+  },
+  activeMap: 'testMap',
+  activeLayer: 0,
+};
+
+const setEditorState = jest.fn();
+
+test('clicking Add layer adds a new layer to active map', () => {
+  const promptSpy = jest
+    .spyOn(window, 'prompt')
+    .mockReturnValue('New Layer');
+
+  render(
+    <EditorContext.Provider value={{ editorState: mockEditorState, setEditorState }}>
+      <LayersPanel />
+    </EditorContext.Provider>
+  );
+
+  fireEvent.click(screen.getByTitle('Add layer'));
+
+  expect(setEditorState).toHaveBeenCalledWith({
+    ...mockEditorState,
+    maps: {
+      ...mockEditorState.maps,
+      testMap: {
+        ...mockEditorState.maps.testMap,
+        layers: [
+          ...mockEditorState.maps.testMap.layers,
+          {
+            tiles: {},
+            visible: true,
+            name: 'New Layer',
+            opacity: 1,
+            locked: false,
+          },
+        ],
+      },
+    },
+  });
+
+  promptSpy.mockRestore();
+});


### PR DESCRIPTION
## Summary
- add handler for "Add layer" to prompt for name and store new layers
- test that clicking the button creates a new layer

## Testing
- `npm run lint` *(fails: Unreachable code; no-unused-vars etc.)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b33f44696483268c195196ea2ad60a