### PR TITLE
Add map creation to editor state

### DIFF
--- a/src/components/LayersPanel.jsx
+++ b/src/components/LayersPanel.jsx
@@ -35,6 +35,30 @@ export default function LayersPanel() {
     setEditorState({ ...editorState, activeMap: e.target.value });
   };
 
+  const handleAddMap = () => {
+    const name = prompt('Enter map name');
+    if (!name) return;
+    const key = name.replace(/\s+/g, '_');
+    const newMap = {
+      name,
+      layers: [],
+      mapWidth: 0,
+      mapHeight: 0,
+      tileSize: editorState.tileSize,
+      width: 0,
+      height: 0,
+      gridColor: '#00FFFF',
+    };
+    setEditorState({
+      ...editorState,
+      maps: {
+        ...maps,
+        [key]: newMap,
+      },
+      activeMap: key,
+    });
+  };
+
   const setLayerIsVisible = (layerIndex) => {
     const newLayers = [...layers];
     newLayers[layerIndex].visible = !newLayers[layerIndex].visible;
@@ -79,7 +103,7 @@ export default function LayersPanel() {
             </option>
           ))}
         </select>
-        <button id="addMapBtn" title="Add tilemap">+</button>
+        <button id="addMapBtn" title="Add tilemap" onClick={handleAddMap}>+</button>
         <button id="removeMapBtn" title="Remove tilemap">-</button>
         <button id="duplicateMapBtn" title="Duplicate tilemap">📑</button>
         <a className="button" href="#popup1">🎚️</a>

--- a/src/components/LayersPanel.test.jsx
+++ b/src/components/LayersPanel.test.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen, fireEvent } from '../utils/test-utils';
+import LayersPanel from './LayersPanel';
+import EditorContext from '../context/EditorContext';
+
+const mockEditorState = {
+  maps: {},
+  activeMap: null,
+  activeLayer: 0,
+  tileSize: 32,
+};
+
+const setEditorState = jest.fn();
+
+const renderComponent = () =>
+  render(
+    <EditorContext.Provider value={{ editorState: mockEditorState, setEditorState }}>
+      <LayersPanel />
+    </EditorContext.Provider>
+  );
+
+test('adds new map to state', () => {
+  window.prompt = jest.fn().mockReturnValue('Test Map');
+  renderComponent();
+  const addButton = screen.getByTitle('Add tilemap');
+  fireEvent.click(addButton);
+  expect(setEditorState).toHaveBeenCalledWith({
+    ...mockEditorState,
+    maps: {
+      ...mockEditorState.maps,
+      Test_Map: {
+        name: 'Test Map',
+        layers: [],
+        mapWidth: 0,
+        mapHeight: 0,
+        tileSize: mockEditorState.tileSize,
+        width: 0,
+        height: 0,
+        gridColor: '#00FFFF',
+      },
+    },
+    activeMap: 'Test_Map',
+  });
+});


### PR DESCRIPTION
## Summary
- add button handler to create a new map by name and store it in editor state
- test that clicking the Add Map button inserts the new map object

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b33f4ccaa88326ab2bbf64fb8f9113