### PR TITLE
Implement basic tile interaction logic

### DIFF
--- a/src/components/MapCanvas.jsx
+++ b/src/components/MapCanvas.jsx
@@ -4,10 +4,11 @@ import useGridCanvas from '../hooks/useGridCanvas';
 import EditorContext from '../context/EditorContext';
 
 export default function MapCanvas() {
-  const { editorState } = useContext(EditorContext);
-  const { zoom, tileSize, maps, activeMap } = editorState;
+  const { editorState, setEditorState } = useContext(EditorContext);
+  const { zoom, tileSize, maps, activeMap, activeLayer = 0, activeTool } = editorState;
   const wrapperRef = useRef(null);
   const canvasRef = useRef(null);
+  const isPointerDown = useRef(false);
 
   const map = maps[activeMap];
   const width = map ? map.width * zoom : 0;
@@ -16,10 +17,68 @@ export default function MapCanvas() {
   useDraggable({ element: wrapperRef, onElement: canvasRef });
   useGridCanvas(canvasRef, width, height, tileSize * zoom, map ? map.gridColor : '#00FFFF');
 
+  const screenToMap = (event) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return { x: 0, y: 0 };
+    const rect = canvas.getBoundingClientRect();
+    const x = Math.floor((event.clientX - rect.left) / (tileSize * zoom));
+    const y = Math.floor((event.clientY - rect.top) / (tileSize * zoom));
+    return { x, y };
+  };
+
+  const applyTool = ({ x, y }) => {
+    if (!map) return;
+    const key = `${x}-${y}`;
+    const layer = map.layers[activeLayer];
+    if (!layer) return;
+    const tiles = { ...layer.tiles };
+
+    if (activeTool === 0) {
+      tiles[key] = { x: 0, y: 0, tilesetIdx: 0 };
+    } else if (activeTool === 1) {
+      delete tiles[key];
+    } else if (activeTool === 3) {
+      return;
+    }
+
+    const newLayers = map.layers.map((l, i) =>
+      i === activeLayer ? { ...l, tiles } : l
+    );
+    setEditorState({
+      ...editorState,
+      maps: {
+        ...maps,
+        [activeMap]: { ...map, layers: newLayers },
+      },
+    });
+  };
+
+  const handlePointerDown = (e) => {
+    isPointerDown.current = true;
+    applyTool(screenToMap(e));
+  };
+
+  const handlePointerMove = (e) => {
+    if (!isPointerDown.current) return;
+    applyTool(screenToMap(e));
+  };
+
+  const handlePointerUp = () => {
+    isPointerDown.current = false;
+  };
+
   return (
     <div className="card_right-column" style={{ position: 'relative' }} id="canvas_drag_area">
       <div className="canvas_wrapper" id="canvas_wrapper" ref={wrapperRef} style={{ position: 'absolute' }}>
-        <canvas id="mapCanvas" ref={canvasRef} width={width} height={height}></canvas>
+        <canvas
+          id="mapCanvas"
+          ref={canvasRef}
+          width={width}
+          height={height}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+        ></canvas>
       </div>
     </div>
   );

--- a/src/components/MapCanvas.test.jsx
+++ b/src/components/MapCanvas.test.jsx
@@ -1,38 +1,160 @@
 import React from 'react';
-import { render } from '../utils/test-utils';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import MapCanvas from './MapCanvas';
 import EditorContext from '../context/EditorContext';
 
-const mockEditorState = {
-  zoom: 1,
-  tileSize: 32,
-  activeTool: 0,
-  maps: {
-    'Map_1': {
-      layers: [],
-      name: 'Map 1',
-      mapWidth: 10,
-      mapHeight: 10,
-      tileSize: 32,
-      width: 320,
-      height: 320,
-      gridColor: '#00FFFF',
-    },
-  },
-  activeMap: 'Map_1',
-  tileSets: {},
+const setup = (initialState) => {
+  let currentState = initialState;
+  const Wrapper = ({ children }) => {
+    const [state, setState] = React.useState(initialState);
+    currentState = state;
+    return (
+      <EditorContext.Provider value={{ editorState: state, setEditorState: setState }}>
+        {children}
+      </EditorContext.Provider>
+    );
+  };
+  const utils = render(<MapCanvas />, { wrapper: Wrapper });
+  const canvas = utils.container.querySelector('#mapCanvas');
+  canvas.getBoundingClientRect = () => ({
+    left: 0,
+    top: 0,
+    right: canvas.width,
+    bottom: canvas.height,
+    width: canvas.width,
+    height: canvas.height,
+  });
+  return { ...utils, canvas, getState: () => currentState };
 };
 
-const renderComponent = () =>
-  render(
-    <EditorContext.Provider value={{ editorState: mockEditorState }}>
-      <MapCanvas />
-    </EditorContext.Provider>
-  );
+beforeAll(() => {
+  if (!window.PointerEvent) {
+    class PointerEvent extends Event {
+      constructor(type, props = {}) {
+        super(type, props);
+        this.clientX = props.clientX || 0;
+        this.clientY = props.clientY || 0;
+      }
+    }
+    window.PointerEvent = PointerEvent;
+  }
+});
 
 test('MapCanvas uses width and height props', () => {
-  const { container } = renderComponent();
-  let canvas = container.querySelector('#mapCanvas');
+  const initialState = {
+    zoom: 1,
+    tileSize: 32,
+    activeTool: 0,
+    maps: {
+      Map_1: {
+        layers: [],
+        name: 'Map 1',
+        mapWidth: 10,
+        mapHeight: 10,
+        tileSize: 32,
+        width: 320,
+        height: 320,
+        gridColor: '#00FFFF',
+      },
+    },
+    activeMap: 'Map_1',
+    activeLayer: 0,
+    tileSets: {},
+  };
+  const { canvas } = setup(initialState);
   expect(canvas.getAttribute('width')).toBe('320');
   expect(canvas.getAttribute('height')).toBe('320');
 });
+
+test('pointer events add tiles when using add tool', async () => {
+  const initialState = {
+    zoom: 1,
+    tileSize: 32,
+    activeTool: 0,
+    maps: {
+      Map_1: {
+        layers: [{ tiles: {}, visible: true, locked: false }],
+        name: 'Map 1',
+        mapWidth: 2,
+        mapHeight: 2,
+        tileSize: 32,
+        width: 64,
+        height: 64,
+        gridColor: '#00FFFF',
+      },
+    },
+    activeMap: 'Map_1',
+    activeLayer: 0,
+    tileSets: {},
+  };
+  const { canvas, getState } = setup(initialState);
+  fireEvent.pointerDown(canvas, { clientX: 16, clientY: 16 });
+  fireEvent.pointerMove(canvas, { clientX: 48, clientY: 16 });
+  fireEvent.pointerUp(canvas);
+  await waitFor(() => {
+    const tiles = getState().maps.Map_1.layers[0].tiles;
+    expect(tiles['0-0']).toBeDefined();
+    expect(tiles['1-0']).toBeDefined();
+  });
+});
+
+test('pointer events remove tiles when using erase tool', async () => {
+  const initialState = {
+    zoom: 1,
+    tileSize: 32,
+    activeTool: 1,
+    maps: {
+      Map_1: {
+        layers: [{ tiles: { '0-0': { x: 0, y: 0, tilesetIdx: 0 } }, visible: true, locked: false }],
+        name: 'Map 1',
+        mapWidth: 2,
+        mapHeight: 2,
+        tileSize: 32,
+        width: 64,
+        height: 64,
+        gridColor: '#00FFFF',
+      },
+    },
+    activeMap: 'Map_1',
+    activeLayer: 0,
+    tileSets: {},
+  };
+  const { canvas, getState } = setup(initialState);
+  fireEvent.pointerDown(canvas, { clientX: 16, clientY: 16 });
+  fireEvent.pointerUp(canvas);
+  await waitFor(() => {
+    const tiles = getState().maps.Map_1.layers[0].tiles;
+    expect(tiles['0-0']).toBeUndefined();
+  });
+});
+
+test('pointer events do not modify tiles when using pick tool', async () => {
+  const initialState = {
+    zoom: 1,
+    tileSize: 32,
+    activeTool: 3,
+    maps: {
+      Map_1: {
+        layers: [{ tiles: { '0-0': { x: 0, y: 0, tilesetIdx: 0 } }, visible: true, locked: false }],
+        name: 'Map 1',
+        mapWidth: 2,
+        mapHeight: 2,
+        tileSize: 32,
+        width: 64,
+        height: 64,
+        gridColor: '#00FFFF',
+      },
+    },
+    activeMap: 'Map_1',
+    activeLayer: 0,
+    tileSets: {},
+  };
+  const { canvas, getState } = setup(initialState);
+  fireEvent.pointerDown(canvas, { clientX: 16, clientY: 16 });
+  fireEvent.pointerUp(canvas);
+  await waitFor(() => {
+    const tiles = getState().maps.Map_1.layers[0].tiles;
+    expect(tiles['0-0']).toBeDefined();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Add pointer event handling to `MapCanvas` for adding, removing, and picking tiles on the active layer
- Convert screen coordinates to map coordinates and update map state accordingly
- Introduce tests confirming tile data changes for add, erase, and pick tools

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b33f61343c8326a4da77e6479fb087