### PR TITLE
Implement tileset management handlers and tests

### DIFF
--- a/src/components/TilesetPanel.jsx
+++ b/src/components/TilesetPanel.jsx
@@ -5,6 +5,8 @@ export default function TilesetPanel() {
   const { editorState, setEditorState } = useContext(EditorContext);
   const { tileSets, activeTileset } = editorState;
   const canvasRef = useRef(null);
+  const addInputRef = useRef(null);
+  const replaceInputRef = useRef(null);
 
   useEffect(() => {
     const activeTilesetData = tileSets[activeTileset];
@@ -27,6 +29,67 @@ export default function TilesetPanel() {
     setEditorState({ ...editorState, activeTileset: e.target.value });
   };
 
+  const handleAddClick = () => {
+    addInputRef.current?.click();
+  };
+
+  const handleReplaceClick = () => {
+    replaceInputRef.current?.click();
+  };
+
+  const readFile = (file) =>
+    new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.onload = (e) => resolve(e.target.result);
+      reader.readAsDataURL(file);
+    });
+
+  const handleAddTileset = async (e) => {
+    const file = e.target.files && e.target.files[0];
+    if (!file) return;
+    const src = await readFile(file);
+    const newKey = Date.now().toString();
+    setEditorState({
+      ...editorState,
+      tileSets: {
+        ...tileSets,
+        [newKey]: { src, name: file.name },
+      },
+      activeTileset: newKey,
+    });
+    e.target.value = '';
+  };
+
+  const handleReplaceTileset = async (e) => {
+    const file = e.target.files && e.target.files[0];
+    if (!file || !activeTileset) return;
+    const src = await readFile(file);
+    setEditorState({
+      ...editorState,
+      tileSets: {
+        ...tileSets,
+        [activeTileset]: {
+          ...tileSets[activeTileset],
+          src,
+          name: file.name,
+        },
+      },
+    });
+    e.target.value = '';
+  };
+
+  const handleRemoveTileset = () => {
+    if (!activeTileset) return;
+    const newTileSets = { ...tileSets };
+    delete newTileSets[activeTileset];
+    const newActive = Object.keys(newTileSets)[0] || null;
+    setEditorState({
+      ...editorState,
+      tileSets: newTileSets,
+      activeTileset: newActive,
+    });
+  };
+
   return (
     <div className="card_left_column">
       <details className="details_container sticky_left" id="tilesetDataDetails" open>
@@ -40,11 +103,29 @@ export default function TilesetPanel() {
                 </option>
               ))}
             </select>
-            <button id="replaceTilesetBtn" title="replace tileset">r</button>
-            <input id="tilesetReplaceInput" type="file" style={{ display: 'none' }} />
-            <button id="addTilesetBtn" title="add tileset">+</button>
-            <input id="tilesetReadInput" type="file" style={{ display: 'none' }} />
-            <button id="removeTilesetBtn" title="remove">-</button>
+            <button id="replaceTilesetBtn" title="replace tileset" onClick={handleReplaceClick}>
+              r
+            </button>
+            <input
+              id="tilesetReplaceInput"
+              type="file"
+              style={{ display: 'none' }}
+              ref={replaceInputRef}
+              onChange={handleReplaceTileset}
+            />
+            <button id="addTilesetBtn" title="add tileset" onClick={handleAddClick}>
+              +
+            </button>
+            <input
+              id="tilesetReadInput"
+              type="file"
+              style={{ display: 'none' }}
+              ref={addInputRef}
+              onChange={handleAddTileset}
+            />
+            <button id="removeTilesetBtn" title="remove" onClick={handleRemoveTileset}>
+              -
+            </button>
           </span>
         </summary>
         <div>

--- a/src/components/TilesetPanel.test.jsx
+++ b/src/components/TilesetPanel.test.jsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import TilesetPanel from './TilesetPanel';
+import EditorContext from '../context/EditorContext';
+
+beforeAll(() => {
+  class FileReaderMock {
+    readAsDataURL(file) {
+      this.result = `data:${file.type};base64,${Buffer.from(file.name).toString('base64')}`;
+      if (this.onload) {
+        this.onload({ target: { result: this.result } });
+      }
+    }
+  }
+  global.FileReader = FileReaderMock;
+});
+
+const setup = (initialState) => {
+  let currentState = initialState;
+  const Wrapper = ({ children }) => {
+    const [state, setState] = React.useState(initialState);
+    currentState = state;
+    return (
+      <EditorContext.Provider value={{ editorState: state, setEditorState: setState }}>
+        {children}
+      </EditorContext.Provider>
+    );
+  };
+  const utils = render(<TilesetPanel />, { wrapper: Wrapper });
+  return { ...utils, getState: () => currentState };
+};
+
+test('adding tileset updates state and UI', async () => {
+  const initialState = {
+    zoom: 1,
+    tileSize: 32,
+    activeTool: 0,
+    maps: {},
+    tileSets: {},
+    activeMap: null,
+    activeTileset: '',
+  };
+  const { container, getState } = setup(initialState);
+  const input = container.querySelector('#tilesetReadInput');
+  const file = new File(['dummy'], 'add.png', { type: 'image/png' });
+  fireEvent.change(input, { target: { files: [file] } });
+  await waitFor(() => {
+    const keys = Object.keys(getState().tileSets);
+    expect(keys.length).toBe(1);
+    expect(getState().tileSets[keys[0]].name).toBe('add.png');
+    expect(getState().activeTileset).toBe(keys[0]);
+    const select = container.querySelector('#tilesetDataSel');
+    expect(select.options.length).toBe(1);
+  });
+});
+
+test('replacing tileset updates existing entry', async () => {
+  const initialState = {
+    zoom: 1,
+    tileSize: 32,
+    activeTool: 0,
+    maps: {},
+    tileSets: { '0': { src: 'old', name: 'old.png' } },
+    activeMap: null,
+    activeTileset: '0',
+  };
+  const { container, getState } = setup(initialState);
+  const input = container.querySelector('#tilesetReplaceInput');
+  const file = new File(['new'], 'new.png', { type: 'image/png' });
+  fireEvent.change(input, { target: { files: [file] } });
+  await waitFor(() => {
+    expect(getState().tileSets['0'].name).toBe('new.png');
+    expect(getState().tileSets['0'].src).not.toBe('old');
+  });
+});
+
+test('removing tileset updates state and select options', () => {
+  const initialState = {
+    zoom: 1,
+    tileSize: 32,
+    activeTool: 0,
+    maps: {},
+    tileSets: { '0': { src: 'a', name: 'a' }, '1': { src: 'b', name: 'b' } },
+    activeMap: null,
+    activeTileset: '0',
+  };
+  const { container, getState } = setup(initialState);
+  const btn = container.querySelector('#removeTilesetBtn');
+  fireEvent.click(btn);
+  const keys = Object.keys(getState().tileSets);
+  expect(keys).toEqual(['1']);
+  expect(getState().activeTileset).toBe('1');
+  const select = container.querySelector('#tilesetDataSel');
+  expect(select.options.length).toBe(1);
+});
+


### PR DESCRIPTION
## Summary
- add add/replace/remove tileset handlers using FileReader to load images and update `editorState.tileSets`
- wire TilesetPanel buttons to handlers so dropdown reflects current tilesets
- test that each tileset action mutates state correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b342b073288326ab9142f64037f693