### PR TITLE
Add dynamic tileset loader selection

### DIFF
--- a/src/components/TilesetPanel.jsx
+++ b/src/components/TilesetPanel.jsx
@@ -1,9 +1,10 @@
 import React, { useContext, useEffect, useRef } from 'react';
 import EditorContext from '../context/EditorContext';
+import tilesetLoaders from '../tilesetLoaders';
 
 export default function TilesetPanel() {
   const { editorState, setEditorState } = useContext(EditorContext);
-  const { tileSets, activeTileset } = editorState;
+  const { tileSets, activeTileset, activeLoader } = editorState;
   const canvasRef = useRef(null);
   const addInputRef = useRef(null);
   const replaceInputRef = useRef(null);
@@ -27,6 +28,10 @@ export default function TilesetPanel() {
 
   const handleTilesetChange = (e) => {
     setEditorState({ ...editorState, activeTileset: e.target.value });
+  };
+
+  const handleLoaderChange = (e) => {
+    setEditorState({ ...editorState, activeLoader: e.target.value });
   };
 
   const handleAddClick = () => {
@@ -135,8 +140,17 @@ export default function TilesetPanel() {
           </div>
           <div className="tileset_opt_field">
             <span>Tileset loader:</span>
-            <select name="tileSetLoaders" id="tileSetLoadersSel">
-              <option value="default">Default</option>
+            <select
+              name="tileSetLoaders"
+              id="tileSetLoadersSel"
+              value={activeLoader}
+              onChange={handleLoaderChange}
+            >
+              {tilesetLoaders.map((loader) => (
+                <option key={loader.id} value={loader.id}>
+                  {loader.name}
+                </option>
+              ))}
             </select>
           </div>
           <div className="tileset_info" id="tilesetSrcLabel"></div>

--- a/src/components/TilesetPanel.test.jsx
+++ b/src/components/TilesetPanel.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import TilesetPanel from './TilesetPanel';
 import EditorContext from '../context/EditorContext';
+import tilesetLoaders from '../tilesetLoaders';
 
 beforeAll(() => {
   class FileReaderMock {
@@ -39,6 +40,7 @@ test('adding tileset updates state and UI', async () => {
     tileSets: {},
     activeMap: null,
     activeTileset: '',
+    activeLoader: 'default',
   };
   const { container, getState } = setup(initialState);
   const input = container.querySelector('#tilesetReadInput');
@@ -63,6 +65,7 @@ test('replacing tileset updates existing entry', async () => {
     tileSets: { '0': { src: 'old', name: 'old.png' } },
     activeMap: null,
     activeTileset: '0',
+    activeLoader: 'default',
   };
   const { container, getState } = setup(initialState);
   const input = container.querySelector('#tilesetReplaceInput');
@@ -83,6 +86,7 @@ test('removing tileset updates state and select options', () => {
     tileSets: { '0': { src: 'a', name: 'a' }, '1': { src: 'b', name: 'b' } },
     activeMap: null,
     activeTileset: '0',
+    activeLoader: 'default',
   };
   const { container, getState } = setup(initialState);
   const btn = container.querySelector('#removeTilesetBtn');
@@ -92,5 +96,23 @@ test('removing tileset updates state and select options', () => {
   expect(getState().activeTileset).toBe('1');
   const select = container.querySelector('#tilesetDataSel');
   expect(select.options.length).toBe(1);
+});
+
+test('loaders populate and selection updates state', () => {
+  const initialState = {
+    zoom: 1,
+    tileSize: 32,
+    activeTool: 0,
+    maps: {},
+    tileSets: {},
+    activeMap: null,
+    activeTileset: '',
+    activeLoader: 'default',
+  };
+  const { container, getState } = setup(initialState);
+  const select = container.querySelector('#tileSetLoadersSel');
+  expect(select.options.length).toBe(tilesetLoaders.length);
+  fireEvent.change(select, { target: { value: tilesetLoaders[1].id } });
+  expect(getState().activeLoader).toBe(tilesetLoaders[1].id);
 });
 

--- a/src/context/EditorContext.jsx
+++ b/src/context/EditorContext.jsx
@@ -20,6 +20,7 @@ export const initialState = {
   isMouseDown: false,
   maps: {},
   tileSets: {},
+  activeLoader: 'default',
 };
 
 export const editorReducer = (state, action) => {

--- a/src/context/EditorProvider.jsx
+++ b/src/context/EditorProvider.jsx
@@ -11,6 +11,7 @@ const EditorProvider = ({ children }) => {
     tileSets: {},
     activeMap: null,
     activeTileset: null,
+    activeLoader: 'default',
   });
 
   useEffect(() => {

--- a/src/tilesetLoaders.js
+++ b/src/tilesetLoaders.js
@@ -1,0 +1,6 @@
+const tilesetLoaders = [
+  { id: 'default', name: 'Default', api: '' },
+  { id: 'example', name: 'Example', api: 'https://example.com/api' },
+];
+
+export default tilesetLoaders;


### PR DESCRIPTION
## Summary
- define tileset loader configurations in a separate module
- render loader options from config and track active loader state
- test loader option population and selection behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b343eae118832691ad36934b6d6169